### PR TITLE
Reset the search bar to be empty when a new show is selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
         <link rel="icon" type="image/svg+xml" href="/vite.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="An interactive blah blah blah." />
-        <title>My Amazing App</title>
+        <title>TV Shows</title>
     </head>
     <body>
         <div id="root"></div>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -35,6 +35,7 @@ function App() {
 
     const handleSelectShow = (e: React.ChangeEvent<HTMLSelectElement>) => {
         setCurrentShow(showsData.find((show) => show.name === e.target.value)!);
+        setSearchedInput("");
     };
 
     useEffect(() => {


### PR DESCRIPTION
This ensures all episodes of the new show are displayed upon selection instead of filtering the episodes by what was searched when the previous show's episodes were displayed.